### PR TITLE
Add watch deletions

### DIFF
--- a/items.c
+++ b/items.c
@@ -553,8 +553,8 @@ void do_item_remove(item *it) {
     MEMCACHED_ITEM_REMOVE(ITEM_key(it), it->nkey, it->nbytes);
     assert((it->it_flags & ITEM_SLABBED) == 0);
     assert(it->refcount > 0);
-
     if (refcount_decr(it) == 0) {
+        LOGGER_LOG(NULL, LOG_DELETIONS, LOGGER_DELETIONS, it);
         item_free(it);
     }
 }

--- a/logger.c
+++ b/logger.c
@@ -137,6 +137,17 @@ static void _logger_log_item_store(logentry *e, const entry_details *d, const vo
     e->size = sizeof(struct logentry_item_store) + nkey;
 }
 
+static void _logger_log_item_deleted(logentry *e, const entry_details *d, const void *entry, va_list ap) {
+    item *it = (item *)entry;
+    struct logentry_deletion *le = (struct logentry_deletion *) e->data;
+    le->nkey = it->nkey;
+    le->it_flags = it->it_flags;
+    le->nbytes = it->nbytes;
+    le->clsid = ITEM_clsid(it);
+    memcpy(le->key, ITEM_key(it), it->nkey);
+    e->size = sizeof(struct logentry_deletion) + le->nkey;
+}
+
 static void _logger_log_conn_event(logentry *e, const entry_details *d, const void *entry, va_list ap) {
     struct sockaddr_in6 *addr = va_arg(ap, struct sockaddr_in6 *);
     socklen_t addrlen = va_arg(ap, socklen_t);
@@ -248,6 +259,20 @@ static int _logger_parse_ee(logentry *e, char *scratch) {
             (long long int)le->exptime, le->latime, le->clsid,
             le->nbytes > 0 ? le->nbytes - 2 : 0); // CLRF
 
+    return total;
+}
+
+static int _logger_parse_ide(logentry *e, char *scratch) {
+    int total;
+    const char *cmd = "na";
+    char keybuf[KEY_MAX_URI_ENCODED_LENGTH];
+    struct logentry_deletion *le = (struct logentry_deletion *) e->data;
+    uriencode(le->key, keybuf, le->nkey, KEY_MAX_URI_ENCODED_LENGTH);
+    total = snprintf(scratch, LOGGER_PARSE_SCRATCH,
+                     "ts=%d.%d gid=%llu type=deleted key=%s cmd=%s clsid=%u size=%d\n",
+                     (int)e->tv.tv_sec, (int)e->tv.tv_usec, (unsigned long long) e->gid,
+                     keybuf,cmd, le->clsid,
+                     le->nbytes > 0 ? le->nbytes - 2 : 0); // CLRF
     return total;
 }
 
@@ -382,6 +407,7 @@ static const entry_details default_entries[] = {
     },
     [LOGGER_CONNECTION_NEW] = {512, LOG_CONNEVENTS, _logger_log_conn_event, _logger_parse_cne, NULL},
     [LOGGER_CONNECTION_CLOSE] = {512, LOG_CONNEVENTS, _logger_log_conn_event, _logger_parse_cce, NULL},
+    [LOGGER_DELETIONS] = {512, LOG_DELETIONS, _logger_log_item_deleted, _logger_parse_ide, NULL},
 #ifdef EXTSTORE
     [LOGGER_EXTSTORE_WRITE] = {512, LOG_EVICTIONS, _logger_log_ext_write, _logger_parse_extw, NULL},
     [LOGGER_COMPACT_START] = {512, LOG_SYSEVENTS, _logger_log_text, _logger_parse_text,

--- a/logger.h
+++ b/logger.h
@@ -22,6 +22,7 @@ enum log_entry_type {
     LOGGER_SLAB_MOVE,
     LOGGER_CONNECTION_NEW,
     LOGGER_CONNECTION_CLOSE,
+    LOGGER_DELETIONS,
 #ifdef EXTSTORE
     LOGGER_EXTSTORE_WRITE,
     LOGGER_COMPACT_START,
@@ -108,6 +109,14 @@ struct logentry_item_store {
     char key[];
 };
 
+struct logentry_deletion {
+    int nbytes;
+    uint16_t it_flags;
+    uint8_t nkey;
+    uint8_t clsid;
+    char key[];
+};
+
 struct logentry_conn_event {
     int transport;
     int reason;
@@ -155,6 +164,7 @@ struct _logentry {
 #define LOG_PROXYREQS  (1<<10) /* command logs from proxy */
 #define LOG_PROXYEVENTS (1<<11) /* error log stream from proxy */
 #define LOG_PROXYUSER (1<<12) /* user generated logs from proxy */
+#define LOG_DELETIONS (1<<13) /* see whats deleted/etc */
 
 typedef struct _logger {
     struct _logger *prev;

--- a/proto_text.c
+++ b/proto_text.c
@@ -2297,6 +2297,8 @@ static void process_watch_command(conn *c, token_t *tokens, const size_t ntokens
                 f |= LOG_PROXYEVENTS;
             } else if ((strcmp(tokens[x].value, "proxyuser") == 0)) {
                 f |= LOG_PROXYUSER;
+            } else if ((strcmp(tokens[x].value, "deletions") == 0)) {
+                f |= LOG_DELETIONS;
             } else {
                 out_string(c, "ERROR");
                 return;


### PR DESCRIPTION
Adds a `watch deletions` support in memcached:

```bash
watch deletions
OK
ts=1666303388.226398 gid=2 type=deleted key=hello cmd=na clsid=1 size=5
ts=1666303404.25740 gid=3 type=deleted key=nice cmd=na clsid=1 size=10
```

the corresponding sets and deletes: 
```bash
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
set hello 0 0 5
hello
STORED
delete hello
DELETED
set nice 0 0 10
1234567890
STORED
delete nice
DELETED
```